### PR TITLE
为版本 0.6.2 的 Radis 增加验证密码功能

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -441,14 +441,12 @@ class TpCache_Plugin implements Typecho_Plugin_Interface
 
         foreach ($keys as $v) {
             foreach ($prefixs as $prefix) {
-                echo $prefix . $v;
                 @self::$cache->delete(md5($prefix . $v));
             }
         }
 
         if (is_null($del_home)) {
             foreach ($prefixs as $prefix) {
-                echo $prefix . '/';
                 @self::$cache->delete(md5($prefix . '/'));
             }
         }

--- a/driver/typecho_redis.class.php
+++ b/driver/typecho_redis.class.php
@@ -7,11 +7,13 @@ class typecho_redis implements TpCache{
     private $host = '127.0.0.1';
     private $port = 11211;
     private $expire = 86400;
+    private $auth = '';
 
     private function __construct($option=null) {
         $this->host = $option->host;
         $this->port = $option->port;
         $this->expire = $option->expire + 0;
+        $this->auth = $option->auth;
         $this->init($option);
     }
 
@@ -27,6 +29,9 @@ class typecho_redis implements TpCache{
         try{
             $this->redis = new Redis();
             $this->redis->connect($this->host, $this->port);
+            if (!empty($this->auth)) {
+                $this->redis->auth($this->auth);
+            }
         }catch (Exception $e){
             echo $e->getMessage();
         }


### PR DESCRIPTION
首先感谢老高的插件。

我为 `0.7` 添加 Redis Auth 功能，但是不能用，保存配置提示 `Redis server went away`，于是我就添加在 `0.6.2`上面了。

这样如果 Redis 设置了密码，也能使用了。

> 标题的 Radis 属于误打 QwQ
